### PR TITLE
Fix translations on landingpage

### DIFF
--- a/_i18n/en_US.yml
+++ b/_i18n/en_US.yml
@@ -108,8 +108,8 @@ views:
     volume: VOLUME
 
   start:
-    bid: Buy
-    ask: Sell
+    bid: Sell
+    ask: Buy
     username: "Username:"
     password: "Password:"
     login: Login


### PR DESCRIPTION
Currently the landingpage is showing the wrong labels for the buy/sell prices. I fixed this by adjusting the translations.